### PR TITLE
feat: use 2016-2020 dataset by default

### DIFF
--- a/app.R
+++ b/app.R
@@ -5,11 +5,20 @@ library(plyr)
 library(lubridate)
 library(dplyr)
 
+source("config.R")
+
+globalVariables(c(NAPS_dataset_path))
+
 options(shiny.autoreload=TRUE)
 
-data <- readr::read_csv("data/CA_NAPS_Daily_2020.csv")
-data$City <- as.factor(data$City)
-data$Pollutant <- as.factor(data$Pollutant)
+cat("Loading the NAPS dataset. Please wait...")
+
+data <- readr::read_csv(NAPS_dataset_path) |>
+  mutate_if(is.character, utf8::utf8_encode) |>
+  mutate(City <- as.factor(City),
+         Pollutant <- as.factor(Pollutant))
+
+cat("Done\n")
 
 # Define UI for application
 ui <- fluidPage(

--- a/config.R
+++ b/config.R
@@ -1,0 +1,6 @@
+# NAPS dataset path
+# By default, it uses the daily data build from 2016-2020, hosted on GitHub.
+# Change it here to point to a local data path, or data covering other time
+# frame instead.
+NAPS_dataset_path <-
+    'https://github.com/netsgnut/canada-naps-data/releases/download/build-latest/CA_NAPS_Daily_2001-2020.csv'


### PR DESCRIPTION
This PR proposes to use the 2016-2020 dataset by default. Notice the dataset is now hosted on GitHub and the loading time may therefore be longer.